### PR TITLE
Реализована корректная отправка Email-уведомлений через SMTP Яндекса 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - SPRING_DATASOURCE_USERNAME=${DB_USER}
       - BOT_NAME=${BOT_NAME}
       - BOT_TOKEN=${BOT_TOKEN}
+      - CRON_EXPRESSION=${CRON_EXPRESSION}
     ports:
       - "8080:8080"
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,12 @@ services:
       - BOT_NAME=${BOT_NAME}
       - BOT_TOKEN=${BOT_TOKEN}
       - CRON_EXPRESSION=${CRON_EXPRESSION}
+      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+      - EMAIL_SENDER=${EMAIL_SENDER}
+      - EMAIL_PASSWORD=${EMAIL_PASSWORD}
     ports:
       - "8080:8080"
+      - "5005:5005"
   db:
     image: postgres:17.0
     container_name: psql-db

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,12 @@
             <artifactId>telegrambots</artifactId>
             <version>5.6.0</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+            <version>4.1.0-M1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/ru/reminder/app/controller/UserController.java
+++ b/src/main/java/ru/reminder/app/controller/UserController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -43,9 +45,14 @@ public class UserController {
                 .body(id);
     }
 
-    @DeleteMapping(("/{id}"))
+    @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteById(@PathVariable Long id) {
         userService.deleteById(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @PatchMapping("/{id}")
+    public User setEmail(@PathVariable Long id, @RequestParam String email) {
+        return userService.setEmail(id, email);
     }
 }

--- a/src/main/java/ru/reminder/app/model/entity/Reminder.java
+++ b/src/main/java/ru/reminder/app/model/entity/Reminder.java
@@ -40,7 +40,7 @@ public class Reminder {
     @Column
     private LocalDateTime remind;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(
             name = "user_id",
             nullable = false,

--- a/src/main/java/ru/reminder/app/model/entity/User.java
+++ b/src/main/java/ru/reminder/app/model/entity/User.java
@@ -36,4 +36,6 @@ public class User {
         this.userName = userName;
         this.password = password;
     }
+    @Column(length = 30)
+    private String email;
 }

--- a/src/main/java/ru/reminder/app/service/EmailService.java
+++ b/src/main/java/ru/reminder/app/service/EmailService.java
@@ -1,0 +1,35 @@
+package ru.reminder.app.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+    private final JavaMailSender javaMailSender;
+
+    @Value("${spring.mail.username}")
+    String sender;
+
+    public void sendEmail(String to, String subject,String body)
+
+    {
+        try {
+            SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+            simpleMailMessage.setFrom(sender);
+            simpleMailMessage.setTo(to);
+            simpleMailMessage.setSubject(subject);
+            simpleMailMessage.setText(body);
+            javaMailSender.send(simpleMailMessage);
+        }
+        catch (Exception exception)
+        {
+            log.error("ОШИБКА ПОЧТЫ: ", exception);
+        }
+    }
+}

--- a/src/main/java/ru/reminder/app/service/ReminderScheduler.java
+++ b/src/main/java/ru/reminder/app/service/ReminderScheduler.java
@@ -25,7 +25,7 @@ public class ReminderScheduler {
 
     private static final String STRING_FORMAT=  "%s\n%s";
 
-    @Scheduled(cron = "${cron}")
+    @Scheduled(cron = "${bot.cron}")
     @Transactional
     public void sendScheduledReminders() {
 

--- a/src/main/java/ru/reminder/app/service/ReminderScheduler.java
+++ b/src/main/java/ru/reminder/app/service/ReminderScheduler.java
@@ -5,9 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import ru.reminder.app.bot.TelegramBot;
-import ru.reminder.app.exception.BusinessException;
 import ru.reminder.app.model.entity.Reminder;
 import ru.reminder.app.repository.ReminderRepository;
 
@@ -22,30 +20,41 @@ public class ReminderScheduler {
 
     private final ReminderRepository reminderRepo;
     private final TelegramBot telegramBot;
+    private final EmailService emailService;
 
-    private static final String STRING_FORMAT=  "%s\n%s";
+    private static final String TELEGRAM_FORMAT=  "%s\n%s";
+    private static final String EMAIL_FORMAT=  "%s";
+
+
 
     @Scheduled(cron = "${bot.cron}")
-    @Transactional
     public void sendScheduledReminders() {
 
         List<Reminder> dueReminders = reminderRepo.findUnnotifiedReminders(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES).plusHours(3));
 
         if (!dueReminders.isEmpty()) {
             for (Reminder reminder : dueReminders) {
+                // String tgText = String.format(TELEGRAM_FORMAT, reminder.getTitle(), reminder.getDescription());
+                String emailText = String.format(EMAIL_FORMAT, reminder.getDescription());
+                String userEmail = reminder.getUser().getEmail();
 
-                try {
-                    String messageText = String.format(STRING_FORMAT, reminder.getTitle(),reminder.getDescription());
-
-                    telegramBot.sendMessage(reminder.getUser().getChatId(), messageText);
-                    reminder.setNotified(true);
-                    reminderRepo.save(reminder);
-
-                } catch (BusinessException e) {
-                    log.error("Ошибка при отправке напоминания ID {}: {}", reminder.getId(), e.getMessage());
+                // try {
+                //    telegramBot.sendMessage(reminder.getUser().getChatId(), tgText);
+                //} catch (Exception e) {
+                //      log.error("Failed to send Telegram for reminder ID {}: {}", reminder.getId(), e.getMessage());
+                //
+                if (userEmail != null) {
+                    try {
+                        emailService.sendEmail(userEmail, reminder.getTitle(), emailText);
+                    } catch (Exception e) {
+                        log.error("Failed to send Email for reminder ID {}: {}", reminder.getId(), e.getMessage());
+                    }
                 }
+                reminder.setNotified(true);
+                reminderRepo.saveAndFlush(reminder);
 
+
+                }
             }
         }
     }
-}

--- a/src/main/java/ru/reminder/app/service/UserService.java
+++ b/src/main/java/ru/reminder/app/service/UserService.java
@@ -1,5 +1,6 @@
 package ru.reminder.app.service;
 
+import org.springframework.transaction.annotation.Transactional;
 import ru.reminder.app.model.dto.UserDto;
 import ru.reminder.app.exception.BusinessException;
 import ru.reminder.app.model.entity.User;
@@ -36,5 +37,12 @@ public class UserService {
     public void deleteById(Long id) {
         User user = getUserById(id);
         userRepository.delete(user);
+    }
+
+    @Transactional
+    public User setEmail(Long userId, String email) {
+        User user = getUserById(userId);
+        user.setEmail(email);
+        return userRepository.save(user);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,20 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: validate
+  mail:
+    host: smtp.yandex.ru
+    port: 465
+    username: ${EMAIL_SENDER}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            enable: true
+            socketFactory:
+              port: 465
+              class: javax.net.ssl.SSLSocketFactory
 
 logging:
   level:
@@ -22,5 +36,4 @@ logging:
 bot:
     name: ${BOT_NAME}
     token: ${BOT_TOKEN}
-
-cron: ${CRON_EXPRESSION}
+    cron: ${CRON_EXPRESSION}

--- a/src/main/resources/db/changelog/changeset/alter-email-column.sql
+++ b/src/main/resources/db/changelog/changeset/alter-email-column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD COLUMN email VARCHAR(30) UNIQUE;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/changelog/changeset/alter-notified-column.sql
   - include:
       file: db/changelog/changeset/alter-chatID-column.sql
+  - include:
+      file: db/changelog/changeset/alter-email-column.sql


### PR DESCRIPTION
## Описание

Теперь у каждого пользователя может быть свой email (по желанию).

### Ставим уведомление на 18:44
<img width="1280" height="735" alt="image" src="https://github.com/user-attachments/assets/136571f0-706d-4f82-95bd-0d10eebd54dd" />

###Письмо приходит в назначенное время
<img width="1413" height="101" alt="image" src="https://github.com/user-attachments/assets/b0eb9386-7147-4428-b2eb-3e91922db872" />

### В базе отображается высланное уведомление. Если успешно пришло письмо и в телеграммм и на почту. Но к сожалению, сегодня телеграмм похоже совсем заблочили, а я не знаю как ставить впн в докер-контейнере, поэтому код с телеграммом закомментирован (ждем лучших дней)
<img width="1280" height="158" alt="image" src="https://github.com/user-attachments/assets/f4d5822d-4351-4bc9-a70c-25678bd5cd9f" />




